### PR TITLE
Support FreeBSD and OpenBSD

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ var platform = os.platform();
 module.exports = {
     win:   platform.match(/^win/),
     linux: platform === 'linux',
-    mac:   platform === 'darwin'
+    mac:   platform === 'darwin',
+    bsd:   platform.match(/bsd$/)
 };


### PR DESCRIPTION
A pretty simple feature-add for BSD families.

I need this so that testcafe can be updated to recognise browsers on FreeBSD.